### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/samueldanielhwang/a03024c4-c857-4b1a-a881-1cda30baa675/c4f41848-4052-4a39-a670-58b28424330b/_apis/work/boardbadge/1a2895b9-bb21-4ad8-827d-e5329ec3e82a)](https://dev.azure.com/samueldanielhwang/a03024c4-c857-4b1a-a881-1cda30baa675/_boards/board/t/c4f41848-4052-4a39-a670-58b28424330b/Microsoft.RequirementCategory)
 # Learn `git` concepts, not commands
 
 **An interactive git tutorial meant to teach you how git works, not just which commands to execute.**


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/samueldanielhwang/a03024c4-c857-4b1a-a881-1cda30baa675/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.